### PR TITLE
[WKP-2767] First ActiveGraphQL implementation

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in activegraphql.gemspec
 gemspec
+
+gem 'byebug', group: [:development, :test]
+gem 'rspec-its', group: [:test]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,72 @@
 # ActiveGraphql
 
-Active Graphql connects classes to GraphQL services.
+ActiveGraphql connects classes to [GrapQL](http://graphql.org/) services.
+The library provides a **Model** class that, when subclassed and configured, encapsulates the communication with the service.
+
+```ruby
+class MyModel < ActiveGraphql::Model
+  configure url: 'http://some-graphql-service/endpoint'
+end
+```
+
+Any subclass of `ActiveGraphql::Model` will provide the following methods:
+
+- **all:** Retrive all objects for the entity.
+- **where(conditions):** Retrieve all objects for the entity finding by conditions.
+- **find_by(conditions):** Retrive first object for the entity finding by conditions.
+
+Any one of these methods returns an `ActiveGraphql::Fetcher` who provides the method `fetch(*graph)` that is responsible of calling the service. The `*graph` arguments allow to specify how the response format will be.
+
+For convention, any method is performing a call to the service with a query, that is resolved based on: model class name, conditions and graph.
+
+**Retrieving all `MyModel` objects (just ask for retrieving `id`)**
+
+```ruby
+>> MyModel.all.fetch(:id).first.id
+=> "1"
+```
+
+Resolved query:
+
+```
+{ myModels { id } }
+```
+
+**Retrieving all `MyModel` objects with `value == "a"` (ask for `id` and `name`)**
+
+```ruby
+>> m = MyModel.where(value: 'a').fetch(:id, :name).first
+
+>> m.id
+=> "3"
+
+>> m.name
+=> "Whatever"
+```
+
+Resolved query:
+
+```
+{ myModels("value": "a") { id, name } }
+```
+
+**Retrieving `MyModel` object with `id == "5"` (ask for `id`, `name` and `nestedObject { id }`)**
+
+```ruby
+>> m = MyModel.bind_by(id: '5').fetch(:id, :name, nested_object: [:description])
+
+>> m.id
+=> "5"
+
+>> m.name
+=> "Whatever"
+
+>> m.nested_object.description
+=> "Some description here"
+```
+
+Resolved query:
+
+```
+{ myModel("id": "5") { id, name, nestedObject { description } } }
+```

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# ActiveGraphql
+# ActiveGraphQL
 
-ActiveGraphql connects classes to [GraphQL](http://graphql.org/) services.
+ActiveGraphQL connects classes to [GraphQL](http://graphql.org/) services.
 The library provides a **Model** class that, when subclassed and configured, encapsulates the communication with the service.
 
 ```ruby
-class MyModel < ActiveGraphql::Model
+class MyModel < ActiveGraphQL::Model
   configure url: 'http://some-graphql-service/endpoint'
 end
 ```
 
-Any subclass of `ActiveGraphql::Model` will provide the following methods:
+Any subclass of `ActiveGraphQL::Model` will provide the following methods:
 
 - **all:** Retrive all objects for the entity.
 - **where(conditions):** Retrieve all objects for the entity finding by conditions.
 - **find_by(conditions):** Retrieve first object for the entity finding by conditions.
 
-Any one of these methods returns an `ActiveGraphql::Fetcher` who provides the method `fetch(*graph)` that is responsible of calling the service. The `*graph` arguments allow to specify how the response format will be.
+Any one of these methods returns an `ActiveGraphQL::Fetcher` who provides the method `fetch(*graph)` that is responsible of calling the service. The `*graph` arguments allow to specify how the response format will be.
 
 For convention, any method is performing a call to the service with a query, that is resolved based on: model class name, conditions and graph.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ActiveGraphql
 
-ActiveGraphql connects classes to [GrapQL](http://graphql.org/) services.
+ActiveGraphql connects classes to [GraphQL](http://graphql.org/) services.
 The library provides a **Model** class that, when subclassed and configured, encapsulates the communication with the service.
 
 ```ruby
@@ -13,7 +13,7 @@ Any subclass of `ActiveGraphql::Model` will provide the following methods:
 
 - **all:** Retrive all objects for the entity.
 - **where(conditions):** Retrieve all objects for the entity finding by conditions.
-- **find_by(conditions):** Retrive first object for the entity finding by conditions.
+- **find_by(conditions):** Retrieve first object for the entity finding by conditions.
 
 Any one of these methods returns an `ActiveGraphql::Fetcher` who provides the method `fetch(*graph)` that is responsible of calling the service. The `*graph` arguments allow to specify how the response format will be.
 
@@ -53,7 +53,7 @@ Resolved query:
 **Retrieving `MyModel` object with `id == "5"` (ask for `id`, `name` and `nestedObject { id }`)**
 
 ```ruby
->> m = MyModel.bind_by(id: '5').fetch(:id, :name, nested_object: [:description])
+>> m = MyModel.find_by(id: '5').fetch(:id, :name, nested_object: [:description])
 
 >> m.id
 => "5"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ActiveGraphQL
 
+[![Build Status](https://travis-ci.org/wakoopa/activegraphql.png)](https://travis-ci.org/wakoopa/activegraphql)
+
 ActiveGraphQL connects classes to [GraphQL](http://graphql.org/) services.
 The library provides a **Model** class that, when subclassed and configured, encapsulates the communication with the service.
 

--- a/activegraphql.gemspec
+++ b/activegraphql.gemspec
@@ -5,7 +5,7 @@ require 'activegraphql/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'activegraphql'
-  spec.version       = ActiveGraphql::VERSION
+  spec.version       = ActiveGraphQL::VERSION
   spec.authors       = ['Wakoopa']
   spec.email         = ['info@wakoopa.com']
 

--- a/activegraphql.gemspec
+++ b/activegraphql.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_dependency 'hashie', '~> 3.4'
+  spec.add_dependency 'activesupport', '~> 4.2'
 end

--- a/activegraphql.gemspec
+++ b/activegraphql.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_dependency 'hashie', '~> 3.4'
   spec.add_dependency 'activesupport', '~> 4.2'
+  spec.add_dependency 'httparty', '~> 0.13'
 end

--- a/lib/activegraphql.rb
+++ b/lib/activegraphql.rb
@@ -1,5 +1,4 @@
 require 'activegraphql/version'
-
-module ActiveGraphql
-  # Your code goes here...
-end
+require 'activegraphql/query'
+require 'activegraphql/fetcher'
+require 'activegraphql/model'

--- a/lib/activegraphql.rb
+++ b/lib/activegraphql.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'activegraphql/version'
 require 'activegraphql/query'
 require 'activegraphql/fetcher'

--- a/lib/activegraphql/fetcher.rb
+++ b/lib/activegraphql/fetcher.rb
@@ -1,0 +1,25 @@
+require 'activegraphql/support/fancy'
+
+module ActiveGraphql
+  class Fetcher < Support::Fancy
+    attr_accessor :url, :klass, :action, :params, :query
+
+    def initialize(attrs)
+      super(attrs)
+      self.query = Query.new(url: url, action: action, params: params)
+    end
+
+    def fetch(graph = {})
+      response = query.get(graph)
+
+      case response
+      when Hash
+        klass.new(query.response_data)
+      when Array
+        query.response_data.map { |h| klass.new(h) }
+      else
+        fail "Unexpected response for query: #{query.response_data} "
+      end
+    end
+  end
+end

--- a/lib/activegraphql/fetcher.rb
+++ b/lib/activegraphql/fetcher.rb
@@ -13,6 +13,7 @@ module ActiveGraphql
 
     def fetch(graph = {})
       response = query.get(graph)
+      return if response.blank?
 
       case response
       when Hash

--- a/lib/activegraphql/fetcher.rb
+++ b/lib/activegraphql/fetcher.rb
@@ -11,8 +11,8 @@ module ActiveGraphql
       self.query = Query.new(url: url, action: action, params: params)
     end
 
-    def fetch(graph = {})
-      response = query.get(graph)
+    def fetch(*graph)
+      response = query.get(*graph)
       return if response.blank?
 
       case response

--- a/lib/activegraphql/fetcher.rb
+++ b/lib/activegraphql/fetcher.rb
@@ -1,6 +1,6 @@
 require 'activegraphql/support/fancy'
 
-module ActiveGraphql
+module ActiveGraphQL
   class Fetcher < Support::Fancy
     attr_accessor :url, :klass, :action, :params, :query
 

--- a/lib/activegraphql/fetcher.rb
+++ b/lib/activegraphql/fetcher.rb
@@ -4,6 +4,8 @@ module ActiveGraphql
   class Fetcher < Support::Fancy
     attr_accessor :url, :klass, :action, :params, :query
 
+    class Error < StandardError; end
+
     def initialize(attrs)
       super(attrs)
       self.query = Query.new(url: url, action: action, params: params)
@@ -14,11 +16,11 @@ module ActiveGraphql
 
       case response
       when Hash
-        klass.new(query.response_data)
+        klass.new(response)
       when Array
-        query.response_data.map { |h| klass.new(h) }
+        response.map { |h| klass.new(h) }
       else
-        fail "Unexpected response for query: #{query.response_data} "
+        fail Error, "Unexpected response for query: #{response}"
       end
     end
   end

--- a/lib/activegraphql/model.rb
+++ b/lib/activegraphql/model.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext'
 require 'hashie/mash'
 
 module ActiveGraphql
@@ -36,17 +37,18 @@ module ActiveGraphql
       end
 
       def where(conditions = {})
-        Fetcher.new(url: configurable_class.url,
-                    klass: self,
-                    action: name.demodulize.underscore.pluralize,
-                    params: conditions)
+        build_fetcher(name.demodulize.underscore.pluralize.to_sym, conditions)
       end
 
       def find_by(conditions = {})
+        build_fetcher(name.demodulize.underscore.to_sym, conditions)
+      end
+
+      def build_fetcher(action, params)
         Fetcher.new(url: configurable_class.url,
                     klass: self,
-                    action: name.demodulize.underscore,
-                    params: conditions)
+                    action: action,
+                    params: params)
       end
     end
   end

--- a/lib/activegraphql/model.rb
+++ b/lib/activegraphql/model.rb
@@ -1,7 +1,7 @@
 require 'active_support/core_ext'
 require 'hashie/mash'
 
-module ActiveGraphql
+module ActiveGraphQL
   class Model < ::Hashie::Mash
     class Error < StandardError; end
 
@@ -33,7 +33,7 @@ module ActiveGraphql
       #  This provides the capability for configuring inheritable classes with
       #  specific configuration to the corresponding graphql service.
       def configurable_class
-        ancestors[ancestors.find_index(ActiveGraphql::Model) - 1]
+        ancestors[ancestors.find_index(ActiveGraphQL::Model) - 1]
       end
 
       def all

--- a/lib/activegraphql/model.rb
+++ b/lib/activegraphql/model.rb
@@ -1,0 +1,53 @@
+require 'hashie/mash'
+
+module ActiveGraphql
+  class Model < ::Hashie::Mash
+    class Error < StandardError; end
+
+    class << self
+      attr_accessor :url
+
+      # This provides hability to configure the class inherited from here.
+      #  Also field classes will have the the configuration.
+      #
+      #  Example:
+      #    class BaseModelToMyService < ActiveGraphql::Model
+      #      configure url: 'http://localhost:3000/graphql'
+      #    end
+      #
+      #    class ModelToMyService < BaseModelToMyService
+      #    end
+      #
+      #    BaseModelToMyService.url
+      #    => "http://localhost:3000/graphql"
+      #
+      #    ModelToMyService.url
+      #    => "http://localhost:3000/graphql"
+      def configure(url: nil)
+        configurable_class.url = url
+      end
+
+      # Resolves the class who is extending from ActiveGraphql::Model.
+      #
+      #  This provides the capability for configuring inheritable classes with
+      #  specific configuration to the corresponding graphql service.
+      def configurable_class
+        ancestors[ancestors.find_index(ActiveGraphql::Model) - 1]
+      end
+
+      def where(conditions = {})
+        Fetcher.new(url: configurable_class.url,
+                    klass: self,
+                    action: name.demodulize.underscore.pluralize,
+                    params: conditions)
+      end
+
+      def find_by(conditions = {})
+        Fetcher.new(url: configurable_class.url,
+                    klass: self,
+                    action: name.demodulize.underscore,
+                    params: conditions)
+      end
+    end
+  end
+end

--- a/lib/activegraphql/model.rb
+++ b/lib/activegraphql/model.rb
@@ -8,8 +8,8 @@ module ActiveGraphql
     class << self
       attr_accessor :url
 
-      # This provides hability to configure the class inherited from here.
-      #  Also field classes will have the the configuration.
+      # This provides ability to configure the class inherited from here.
+      #  Also field classes will have the configuration.
       #
       #  Example:
       #    class BaseModelToMyService < ActiveGraphql::Model

--- a/lib/activegraphql/model.rb
+++ b/lib/activegraphql/model.rb
@@ -36,6 +36,10 @@ module ActiveGraphql
         ancestors[ancestors.find_index(ActiveGraphql::Model) - 1]
       end
 
+      def all
+        build_fetcher(name.demodulize.underscore.pluralize.to_sym)
+      end
+
       def where(conditions = {})
         build_fetcher(name.demodulize.underscore.pluralize.to_sym, conditions)
       end

--- a/lib/activegraphql/model.rb
+++ b/lib/activegraphql/model.rb
@@ -48,7 +48,7 @@ module ActiveGraphql
         build_fetcher(name.demodulize.underscore.to_sym, conditions)
       end
 
-      def build_fetcher(action, params)
+      def build_fetcher(action, params = nil)
         Fetcher.new(url: configurable_class.url,
                     klass: self,
                     action: action,

--- a/lib/activegraphql/query.rb
+++ b/lib/activegraphql/query.rb
@@ -13,7 +13,7 @@ module ActiveGraphql
 
       self.response = HTTParty.get(url, query: { query: to_s })
 
-      fail(ServerError, response_error_messages) if response_errors.present?
+      raise(ServerError, response_error_messages) if response_errors.present?
       response_data
     end
 
@@ -44,20 +44,24 @@ module ActiveGraphql
     def qparams
       return if params.blank?
 
-      params.map do |k, v|
+      param_strings = params.map do |k, v|
         "#{k.to_s.camelize(:lower)}: \"#{v}\""
-      end.join(', ')
+      end
+
+      param_strings.join(', ')
     end
 
     def qgraph(graph)
-      graph.map do |item|
+      graph_strings = graph.map do |item|
         case item
         when Symbol
           item.to_s.camelize(:lower)
-        when Hash then
+        when Hash
           item.map { |k, v| "#{k.to_s.camelize(:lower)} { #{qgraph(v)} }" }
         end
-      end.join(', ')
+      end
+
+      graph_strings.join(', ')
     end
 
     private

--- a/lib/activegraphql/query.rb
+++ b/lib/activegraphql/query.rb
@@ -1,0 +1,64 @@
+require 'active_support/inflector'
+require 'activegraphql/support/fancy'
+
+module ActiveGraphql
+  class Query < Support::Fancy
+    attr_accessor :url, :action, :params, :graph, :response
+
+    class ServerError < StandardError; end
+
+    def get(*graph)
+      self.graph = graph
+      self.response = HTTParty.get(url, query: { query: to_s })
+
+      fail(ServerError, response_error_messages) if response_errors.present?
+      response_data
+    end
+
+    def response_data
+      return unless response['data']
+      to_snake_case(response['data'][qaction])
+    end
+
+    def response_errors
+      to_snake_case(response['errors'])
+    end
+
+    def response_error_messages
+      response_errors.map { |e| e[:message] }
+    end
+
+    def to_s
+      "{ #{qaction}(#{qparams}) { #{qgraph} } }"
+    end
+
+    private
+
+    def qaction
+      action.to_s.camelize(:lower)
+    end
+
+    def qparams
+      params.map do |k, v|
+        "#{k.to_s.camelize(:lower)}:\"#{v}\""
+      end.join(',')
+    end
+
+    def qgraph
+      graph.map do |k|
+        k.to_s.camelize(:lower)
+      end.join
+    end
+
+    def to_snake_case(value)
+      case value
+      when Array
+        value.map { |v| to_snake_case(v) }
+      when Hash
+        Hash[value.map { |k, v| [k.to_s.underscore.to_sym, to_snake_case(v)] }]
+      else
+        value
+      end
+    end
+  end
+end

--- a/lib/activegraphql/query.rb
+++ b/lib/activegraphql/query.rb
@@ -2,7 +2,7 @@ require 'httparty'
 require 'active_support/inflector'
 require 'activegraphql/support/fancy'
 
-module ActiveGraphql
+module ActiveGraphQL
   class Query < Support::Fancy
     attr_accessor :url, :action, :params, :graph, :response
 

--- a/lib/activegraphql/query.rb
+++ b/lib/activegraphql/query.rb
@@ -31,7 +31,10 @@ module ActiveGraphql
     end
 
     def to_s
-      "{ #{qaction}(#{qparams}) { #{qgraph(graph)} } }"
+      str = "{ #{qaction}"
+      str << (qparams.present? ? "(#{qparams}) {" : ' {')
+      str << " #{qgraph(graph)} } }"
+      str
     end
 
     def qaction
@@ -39,6 +42,8 @@ module ActiveGraphql
     end
 
     def qparams
+      return if params.blank?
+
       params.map do |k, v|
         "#{k.to_s.camelize(:lower)}: \"#{v}\""
       end.join(', ')

--- a/lib/activegraphql/support/fancy.rb
+++ b/lib/activegraphql/support/fancy.rb
@@ -1,0 +1,9 @@
+module ActiveGraphql
+  module Support
+    class Fancy
+      def initialize(attrs = {})
+        attrs.each { |k, v| send("#{k}=", v) if respond_to?("#{k}=") }
+      end
+    end
+  end
+end

--- a/lib/activegraphql/support/fancy.rb
+++ b/lib/activegraphql/support/fancy.rb
@@ -1,4 +1,4 @@
-module ActiveGraphql
+module ActiveGraphQL
   module Support
     class Fancy
       def initialize(attrs = {})

--- a/lib/activegraphql/version.rb
+++ b/lib/activegraphql/version.rb
@@ -1,3 +1,3 @@
-module ActiveGraphql
+module ActiveGraphQL
   VERSION = '0.1.0'
 end

--- a/spec/activegraphql/fetcher_spec.rb
+++ b/spec/activegraphql/fetcher_spec.rb
@@ -41,6 +41,14 @@ describe ActiveGraphql::Fetcher do
       its(:field) { is_expected.to eq 'value1' }
     end
 
+    context 'with nil response' do
+      let(:query_response) { nil }
+
+      subject { fetcher.fetch(graph) }
+
+      it { is_expected.to be_nil }
+    end
+
     context 'with unexpected response' do
       let(:query_response) { double(:unexpected) }
 

--- a/spec/activegraphql/fetcher_spec.rb
+++ b/spec/activegraphql/fetcher_spec.rb
@@ -1,4 +1,4 @@
-describe ActiveGraphql::Fetcher do
+describe ActiveGraphQL::Fetcher do
   let(:fetcher) do
     described_class.new(url: url,
                         klass: Class.new(::Hashie::Mash),
@@ -14,7 +14,7 @@ describe ActiveGraphql::Fetcher do
   let(:graph) { [:some, graph: [:with, :stuff]] }
 
   before do
-    expect(ActiveGraphql::Query)
+    expect(ActiveGraphQL::Query)
       .to receive(:new).with(url: url,
                              action: action,
                              params: params).and_return(query)
@@ -61,7 +61,7 @@ describe ActiveGraphql::Fetcher do
       subject { fetcher.fetch(*graph) }
 
       it 'fails with unexpected error' do
-        expect { subject }.to raise_error(ActiveGraphql::Fetcher::Error)
+        expect { subject }.to raise_error(ActiveGraphQL::Fetcher::Error)
       end
     end
   end

--- a/spec/activegraphql/fetcher_spec.rb
+++ b/spec/activegraphql/fetcher_spec.rb
@@ -11,7 +11,7 @@ describe ActiveGraphql::Fetcher do
   let(:action) { :some_action }
   let(:params) { { some: 'params' } }
   let(:query) { double(:query) }
-  let(:graph) { double(:graph) }
+  let(:graph) { [:some, graph: [:with, :stuff]] }
 
   before do
     expect(ActiveGraphql::Query)
@@ -22,7 +22,7 @@ describe ActiveGraphql::Fetcher do
 
   describe '#fetch' do
     before do
-      expect(query).to receive(:get).with(graph).and_return(query_response)
+      expect(query).to receive(:get).with(*graph).and_return(query_response)
     end
 
     context 'with hash response' do
@@ -30,7 +30,7 @@ describe ActiveGraphql::Fetcher do
         { field: 'value', nested_object: { field: 'value' } }
       end
 
-      subject { fetcher.fetch(graph) }
+      subject { fetcher.fetch(*graph) }
 
       its(:field) { is_expected.to eq 'value' }
 
@@ -42,7 +42,7 @@ describe ActiveGraphql::Fetcher do
     context 'with array response' do
       let(:query_response) { [{ field: 'value1' }, { field: 'value2' }] }
 
-      subject { fetcher.fetch(graph).first }
+      subject { fetcher.fetch(*graph).first }
 
       its(:field) { is_expected.to eq 'value1' }
     end
@@ -50,7 +50,7 @@ describe ActiveGraphql::Fetcher do
     context 'with nil response' do
       let(:query_response) { nil }
 
-      subject { fetcher.fetch(graph) }
+      subject { fetcher.fetch(*graph) }
 
       it { is_expected.to be_nil }
     end
@@ -58,7 +58,7 @@ describe ActiveGraphql::Fetcher do
     context 'with unexpected response' do
       let(:query_response) { double(:unexpected) }
 
-      subject { fetcher.fetch(graph) }
+      subject { fetcher.fetch(*graph) }
 
       it 'fails with unexpected error' do
         expect { subject }.to raise_error(ActiveGraphql::Fetcher::Error)

--- a/spec/activegraphql/fetcher_spec.rb
+++ b/spec/activegraphql/fetcher_spec.rb
@@ -1,0 +1,54 @@
+describe ActiveGraphql::Fetcher do
+  let(:fetcher) do
+    described_class.new(url: url,
+                        klass: Class.new(::Hashie::Mash),
+                        action: action,
+                        params: params)
+  end
+
+  let(:url) { 'some-url' }
+  let(:klass) { Class.new(::Hashie::Mash) }
+  let(:action) { :some_action }
+  let(:params) { { some: 'params' } }
+  let(:query) { double(:query) }
+  let(:graph) { double(:graph) }
+
+  before do
+    expect(ActiveGraphql::Query)
+      .to receive(:new).with(url: url,
+                             action: action,
+                             params: params).and_return(query)
+  end
+
+  describe '#fetch' do
+    before do
+      expect(query).to receive(:get).with(graph).and_return(query_response)
+    end
+
+    context 'with hash response' do
+      let(:query_response) { { field: 'value' } }
+
+      subject { fetcher.fetch(graph) }
+
+      its(:field) { is_expected.to eq 'value' }
+    end
+
+    context 'with array response' do
+      let(:query_response) { [{ field: 'value1' }, { field: 'value2' }] }
+
+      subject { fetcher.fetch(graph).first }
+
+      its(:field) { is_expected.to eq 'value1' }
+    end
+
+    context 'with unexpected response' do
+      let(:query_response) { double(:unexpected) }
+
+      subject { fetcher.fetch(graph) }
+
+      it 'fails with unexpected error' do
+        expect { subject }.to raise_error(ActiveGraphql::Fetcher::Error)
+      end
+    end
+  end
+end

--- a/spec/activegraphql/fetcher_spec.rb
+++ b/spec/activegraphql/fetcher_spec.rb
@@ -26,11 +26,17 @@ describe ActiveGraphql::Fetcher do
     end
 
     context 'with hash response' do
-      let(:query_response) { { field: 'value' } }
+      let(:query_response) do
+        { field: 'value', nested_object: { field: 'value' } }
+      end
 
       subject { fetcher.fetch(graph) }
 
       its(:field) { is_expected.to eq 'value' }
+
+      it 'also works with nested objects' do
+        expect(subject.nested_object.field).to eq 'value'
+      end
     end
 
     context 'with array response' do

--- a/spec/activegraphql/model_spec.rb
+++ b/spec/activegraphql/model_spec.rb
@@ -1,13 +1,13 @@
 describe ActiveGraphql::Model do
+  let(:configured_class) do
+    ConfiguredClass ||= Class.new(described_class) do
+      configure url: 'service_url'
+    end
+  end
+
   describe '.build_fetcher' do
     let(:action) { 'some_action' }
     let(:params) { 'some_params' }
-
-    let(:configured_class) do
-      Class.new(described_class) do
-        configure url: 'service_url'
-      end
-    end
 
     subject { klass.build_fetcher(action, params) }
 
@@ -30,57 +30,54 @@ describe ActiveGraphql::Model do
     end
   end
 
-  describe '.all' do
-    let(:klass) do
-      Object.const_set 'MyAllEntity', Class.new(described_class)
-    end
-
+  shared_context 'with expected fetcher', with_expected_fetcher: true do
     let(:fetcher) { double(:fetcher) }
 
     before do
-      expect(described_class)
-        .to receive(:build_fetcher).with(:my_all_entities).and_return(fetcher)
+      expect(ActiveGraphql::Fetcher)
+        .to receive(:new).with(expected_fetcher_params).and_return(fetcher)
+    end
+  end
+
+  describe '.all', with_expected_fetcher: true do
+    let(:expected_fetcher_params) do
+      { url: 'service_url',
+        klass: configured_class,
+        action: :configured_classes,
+        params: nil }
     end
 
-    subject { klass.all }
+    subject { configured_class.all }
 
     it { is_expected.to be fetcher }
   end
 
-  describe '.where' do
+  describe '.where', with_expected_fetcher: true  do
     let(:conditions) { double(:conditions) }
 
-    let(:klass) do
-      Object.const_set 'MyWhereEntity', Class.new(described_class)
+    let(:expected_fetcher_params) do
+      { url: 'service_url',
+        klass: configured_class,
+        action: :configured_classes,
+        params: conditions }
     end
 
-    let(:fetcher) { double(:fetcher) }
-
-    before do
-      expect(described_class)
-        .to receive(:build_fetcher).with(:my_where_entities, conditions).and_return(fetcher)
-    end
-
-    subject { klass.where(conditions) }
+    subject { configured_class.where(conditions) }
 
     it { is_expected.to be fetcher }
   end
 
-  describe '.find_by' do
+  describe '.find_by', with_expected_fetcher: true  do
     let(:conditions) { double(:conditions) }
 
-    let(:klass) do
-      Object.const_set 'MyFindByEntity', Class.new(described_class)
+    let(:expected_fetcher_params) do
+      { url: 'service_url',
+        klass: configured_class,
+        action: :configured_class,
+        params: conditions }
     end
 
-    let(:fetcher) { double(:fetcher) }
-
-    before do
-      expect(described_class)
-        .to receive(:build_fetcher).with(:my_find_by_entity, conditions).and_return(fetcher)
-    end
-
-    subject { klass.find_by(conditions) }
+    subject { configured_class.find_by(conditions) }
 
     it { is_expected.to be fetcher }
   end

--- a/spec/activegraphql/model_spec.rb
+++ b/spec/activegraphql/model_spec.rb
@@ -1,0 +1,70 @@
+describe ActiveGraphql::Model do
+  describe '.build_fetcher' do
+    let(:action) { 'some_action' }
+    let(:params) { 'some_params' }
+
+    let(:configured_class) do
+      Class.new(described_class) do
+        configure url: 'service_url'
+      end
+    end
+
+    subject { klass.build_fetcher(action, params) }
+
+    context 'with configured class' do
+      let(:klass) { configured_class }
+
+      its(:url) { is_expected.to eq 'service_url' }
+      its(:klass) { is_expected.to eq klass }
+      its(:action) { is_expected.to eq action }
+      its(:params) { is_expected.to eq params }
+    end
+
+    context 'with class inheriting the configured one' do
+      let(:klass) { Class.new(configured_class) }
+
+      its(:url) { is_expected.to eq 'service_url' }
+      its(:klass) { is_expected.to eq klass }
+      its(:action) { is_expected.to eq action }
+      its(:params) { is_expected.to eq params }
+    end
+  end
+
+  describe '.where' do
+    let(:conditions) { double(:conditions) }
+
+    let(:klass) do
+      Object.const_set 'MyWhereEntity', Class.new(described_class)
+    end
+
+    let(:fetcher) { double(:fetcher) }
+
+    before do
+      expect(described_class)
+        .to receive(:build_fetcher).with(:my_where_entities, conditions).and_return(fetcher)
+    end
+
+    subject { klass.where(conditions) }
+
+    it { is_expected.to be fetcher }
+  end
+
+  describe '.find_by' do
+    let(:conditions) { double(:conditions) }
+
+    let(:klass) do
+      Object.const_set 'MyFindByEntity', Class.new(described_class)
+    end
+
+    let(:fetcher) { double(:fetcher) }
+
+    before do
+      expect(described_class)
+        .to receive(:build_fetcher).with(:my_find_by_entity, conditions).and_return(fetcher)
+    end
+
+    subject { klass.find_by(conditions) }
+
+    it { is_expected.to be fetcher }
+  end
+end

--- a/spec/activegraphql/model_spec.rb
+++ b/spec/activegraphql/model_spec.rb
@@ -1,4 +1,4 @@
-describe ActiveGraphql::Model do
+describe ActiveGraphQL::Model do
   let(:configured_class) do
     ConfiguredClass ||= Class.new(described_class) do
       configure url: 'service_url'
@@ -34,7 +34,7 @@ describe ActiveGraphql::Model do
     let(:fetcher) { double(:fetcher) }
 
     before do
-      expect(ActiveGraphql::Fetcher)
+      expect(ActiveGraphQL::Fetcher)
         .to receive(:new).with(expected_fetcher_params).and_return(fetcher)
     end
   end

--- a/spec/activegraphql/model_spec.rb
+++ b/spec/activegraphql/model_spec.rb
@@ -30,6 +30,23 @@ describe ActiveGraphql::Model do
     end
   end
 
+  describe '.all' do
+    let(:klass) do
+      Object.const_set 'MyAllEntity', Class.new(described_class)
+    end
+
+    let(:fetcher) { double(:fetcher) }
+
+    before do
+      expect(described_class)
+        .to receive(:build_fetcher).with(:my_all_entities).and_return(fetcher)
+    end
+
+    subject { klass.all }
+
+    it { is_expected.to be fetcher }
+  end
+
   describe '.where' do
     let(:conditions) { double(:conditions) }
 

--- a/spec/activegraphql/query_rspec.rb
+++ b/spec/activegraphql/query_rspec.rb
@@ -1,0 +1,86 @@
+describe ActiveGraphql::Query do
+  let(:query) do
+    described_class.new(url: url,
+                        action: action,
+                        params: params)
+  end
+
+  let(:url) { 'some-url' }
+  let(:action) { :some_long_action_name }
+  let(:params) do
+    { some_long_param_name1: 'value1',
+      some_long_param_name2: 'value2' }
+  end
+
+  let(:graph) do
+    [:attr1,
+     { object: [:nested_attr, nested_object: [:super_nested_attr]] },
+     :attr2]
+  end
+
+  let(:expected_query) do
+    '{ someLongActionName'\
+    '(someLongParamName1: "value1", someLongParamName2: "value2") { ' \
+    'attr1, object { nestedAttr, nestedObject { superNestedAttr } }, attr2 }' \
+    ' }'
+  end
+
+  describe '#get' do
+    before do
+      expect(HTTParty)
+        .to receive(:get).with(url, query: { query: expected_query }).and_return(response)
+    end
+
+    subject { query.get(*graph) }
+
+    context 'with no errors in the response' do
+      let(:response) do
+        { 'data' => { 'someLongActionName' => { 'someExpected' => 'data' } } }
+      end
+
+      it { is_expected.to eq(some_expected: 'data') }
+    end
+
+    context 'with errors in the response' do
+      let(:response) do
+        {
+          'errors' => [
+            { 'message' => 'message1' },
+            { 'message' => 'message2' }
+          ]
+        }
+      end
+
+      it 'fails with an error' do
+        expect { subject }.to raise_error(ActiveGraphql::Query::ServerError,
+                                          /"message1", "message2"/)
+      end
+    end
+  end
+
+  describe '#to_s' do
+    subject do
+      query.tap { |q| q.graph = graph }.to_s
+    end
+
+    it { is_expected.to eq expected_query }
+  end
+
+  describe '#qaction' do
+    subject { query.qaction }
+
+    it { is_expected.to eq 'someLongActionName' }
+  end
+
+  describe 'qparams' do
+    subject { query.qparams }
+
+    it { is_expected.to eq "someLongParamName1: \"value1\", someLongParamName2: \"value2\"" }
+  end
+
+  describe '#qgraph' do
+    subject { query.qgraph(graph) }
+
+    it { is_expected.to eq 'attr1, object { nestedAttr, nestedObject { superNestedAttr } }, attr2' }
+  end
+end

--- a/spec/activegraphql/query_spec.rb
+++ b/spec/activegraphql/query_spec.rb
@@ -18,17 +18,24 @@ describe ActiveGraphql::Query do
      :attr2]
   end
 
-  let(:expected_query) do
+  let(:expected_query_with_params) do
     '{ someLongActionName'\
     '(someLongParamName1: "value1", someLongParamName2: "value2") { ' \
     'attr1, object { nestedAttr, nestedObject { superNestedAttr } }, attr2 }' \
     ' }'
   end
 
+  let(:expected_query_without_params) do
+    '{ someLongActionName { ' \
+    'attr1, object { nestedAttr, nestedObject { superNestedAttr } }, attr2 }' \
+    ' }'
+  end
+
   describe '#get' do
     before do
-      expect(HTTParty)
-        .to receive(:get).with(url, query: { query: expected_query }).and_return(response)
+      expect(HTTParty).to receive(:get)
+        .with(url, query: { query: expected_query_with_params })
+        .and_return(response)
     end
 
     subject { query.get(*graph) }
@@ -63,7 +70,15 @@ describe ActiveGraphql::Query do
       query.tap { |q| q.graph = graph }.to_s
     end
 
-    it { is_expected.to eq expected_query }
+    context 'without params' do
+      let(:params) { nil }
+
+      it { is_expected.to eq expected_query_without_params }
+    end
+
+    context 'with params' do
+      it { is_expected.to eq expected_query_with_params }
+    end
   end
 
   describe '#qaction' do
@@ -75,7 +90,15 @@ describe ActiveGraphql::Query do
   describe 'qparams' do
     subject { query.qparams }
 
-    it { is_expected.to eq "someLongParamName1: \"value1\", someLongParamName2: \"value2\"" }
+    context 'without params' do
+      let(:params) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with params' do
+      it { is_expected.to eq "someLongParamName1: \"value1\", someLongParamName2: \"value2\"" }
+    end
   end
 
   describe '#qgraph' do

--- a/spec/activegraphql/query_spec.rb
+++ b/spec/activegraphql/query_spec.rb
@@ -1,4 +1,4 @@
-describe ActiveGraphql::Query do
+describe ActiveGraphQL::Query do
   let(:query) do
     described_class.new(url: url,
                         action: action,
@@ -59,7 +59,7 @@ describe ActiveGraphql::Query do
       end
 
       it 'fails with an error' do
-        expect { subject }.to raise_error(ActiveGraphql::Query::ServerError,
+        expect { subject }.to raise_error(ActiveGraphQL::Query::ServerError,
                                           /"message1", "message2"/)
       end
     end

--- a/spec/activegraphql_spec.rb
+++ b/spec/activegraphql_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe ActiveGraphql do
   it 'has a version number' do
     expect(ActiveGraphql::VERSION).not_to be nil

--- a/spec/activegraphql_spec.rb
+++ b/spec/activegraphql_spec.rb
@@ -1,5 +1,5 @@
-describe ActiveGraphql do
+describe ActiveGraphQL do
   it 'has a version number' do
-    expect(ActiveGraphql::VERSION).not_to be nil
+    expect(ActiveGraphQL::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'rspec/its'
 require 'activegraphql'


### PR DESCRIPTION
This is the first implementation to serve the following purpose:

You can create a `BaseModel` and configure it for accessing your GraphQL service:

``` ruby
class BaseModel < ActiveGraphql::Model
  configure url: 'http://localhost::3000/graphql'
end
```

You can extend your `BaseModel` (it preserves the configuration):

``` ruby
class MobileProvider < BaseModel
end

class Country < BaseModel
end
```

You can use your model to access the service:

``` ruby
>> MobileProvider.where(country_code: 'uk').fetch(:apn_host).first
=> #<Wakoopa::Sdk::Condor::MobileProvider apn_host="data.lycamobile.co.uk">

>> Wakoopa::Sdk::Condor::MobileProvider.find_by(country_code: 'uk', code: 'orange').fetch(:name)
=> #<Wakoopa::Sdk::Condor::MobileProvider name="Orange">

>> Wakoopa::Sdk::Condor::Country.all.fetch(:code).first
=> #<Wakoopa::Sdk::Condor::Country code="dk">
```
