### PR TITLE
Add support for localized services

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ Resolved query:
 Any fetcher provides the `in_locale(locale)` method that makes the call to include the `HTTP_ACCEPT_LANGUAGE` header to get the content localized in case of the service supporting it.
 
 ```ruby
->> MyModel.all.in_locale(:en).fetch(:body).first.body
+>> MyModel.all.in_locale(:en).fetch(:some_attribute).first.some_attribute
 => "This is my text"
 
->> MyModel.all.in_locale(:es).fetch(:body).first.body
+>> MyModel.all.in_locale(:es).fetch(:some_attribute).first.some_attribute
 => "Este es mi texto"
 
 # Also accepts strings as locale
->> MyModel.all.in_locale('es_ES').fetch(:body).first.body
+>> MyModel.all.in_locale('es_ES').fetch(:some_attribute).first.some_attribute
 => "Este es mi texto"
 ```

--- a/README.md
+++ b/README.md
@@ -72,3 +72,18 @@ Resolved query:
 ```
 { myModel("id": "5") { id, name, nestedObject { description } } }
 ```
+
+## Localisation support
+Any fetcher provides the `in_locale(locale)` method that makes the call to include the `HTTP_ACCEPT_LANGUAGE` header to get the content localized in case of the service supporting it.
+
+```ruby
+>> MyModel.all.in_locale(:en).fetch(:body).first.body
+=> "This is my text"
+
+>> MyModel.all.in_locale(:es).fetch(:body).first.body
+=> "Este es mi texto"
+
+# Also accepts strings as locale
+>> MyModel.all.in_locale('es_ES').fetch(:body).first.body
+=> "Este es mi texto"
+```

--- a/lib/activegraphql/fetcher.rb
+++ b/lib/activegraphql/fetcher.rb
@@ -8,7 +8,15 @@ module ActiveGraphQL
 
     def initialize(attrs)
       super(attrs)
-      self.query = Query.new(url: url, action: action, params: params)
+    end
+
+    def query
+      @query ||= Query.new(url: url, action: action, params: params)
+    end
+
+    def in_locale(locale)
+      query.locale = locale if locale.present?
+      self
     end
 
     def fetch(*graph)

--- a/lib/activegraphql/query.rb
+++ b/lib/activegraphql/query.rb
@@ -4,17 +4,23 @@ require 'activegraphql/support/fancy'
 
 module ActiveGraphQL
   class Query < Support::Fancy
-    attr_accessor :url, :action, :params, :graph, :response
+    attr_accessor :url, :action, :params, :locale, :graph, :response
 
     class ServerError < StandardError; end
 
     def get(*graph)
       self.graph = graph
 
-      self.response = HTTParty.get(url, query: { query: to_s })
+      self.response = HTTParty.get(url, request_options)
 
       raise(ServerError, response_error_messages) if response_errors.present?
       response_data
+    end
+
+    def request_options
+      { query: { query: to_s } }.tap do |opts|
+        opts.merge!(headers: { 'accept_language' => locale.to_s }) if locale.present?
+      end
     end
 
     def response_data

--- a/spec/activegraphql/fetcher_spec.rb
+++ b/spec/activegraphql/fetcher_spec.rb
@@ -13,15 +13,23 @@ describe ActiveGraphQL::Fetcher do
   let(:query) { double(:query) }
   let(:graph) { [:some, graph: [:with, :stuff]] }
 
-  before do
-    expect(ActiveGraphQL::Query)
-      .to receive(:new).with(url: url,
-                             action: action,
-                             params: params).and_return(query)
+  describe '#in_locale' do
+    context 'with locale' do
+      let(:locale) { :some_locale }
+
+      subject { fetcher.in_locale(locale).query }
+
+      its(:locale) { is_expected.to eq locale }
+    end
   end
 
   describe '#fetch' do
     before do
+      expect(ActiveGraphQL::Query)
+        .to receive(:new).with(url: url,
+                               action: action,
+                               params: params).and_return(query)
+
       expect(query).to receive(:get).with(*graph).and_return(query_response)
     end
 

--- a/spec/activegraphql/query_spec.rb
+++ b/spec/activegraphql/query_spec.rb
@@ -33,12 +33,15 @@ describe ActiveGraphQL::Query do
 
   describe '#get' do
     before do
-      expect(HTTParty).to receive(:get)
-        .with(url, query: { query: expected_query_with_params })
-        .and_return(response)
+      expect(HTTParty)
+        .to receive(:get).with(url, expected_request_options).and_return(response)
     end
 
     subject { query.get(*graph) }
+
+    let(:expected_request_options) do
+      { query: { query: expected_query_with_params } }
+    end
 
     context 'with no errors in the response' do
       let(:response) do
@@ -46,6 +49,19 @@ describe ActiveGraphQL::Query do
       end
 
       it { is_expected.to eq(some_expected: 'data') }
+
+      context 'with locale' do
+        let(:locale) { :en }
+
+        let(:expected_request_options) do
+          { headers: { 'accept_language' => locale.to_s },
+            query: { query: expected_query_with_params } }
+        end
+
+        before { query.locale = locale }
+
+        it { is_expected.to eq(some_expected: 'data') }
+      end
     end
 
     context 'with errors in the response' do


### PR DESCRIPTION
This PR adds support for fetching localised data, from services that supports localisation based on `HTTP_ACCEPT_LANGUAGE` header.

It provides the `in_locale` method to the `ActiveGraphQL::Fetcher` to do so. Having this feature you could get content localised doing something like:

``` ruby
>> MyModel.all.in_locale(:en).fetch(:body).first.body
=> "This is my text"

>> MyModel.all.in_locale(:es).fetch(:body).first.body
=> "Este es mi texto"
```
