### PR TITLE
Avoid underscored header

### DIFF
--- a/lib/activegraphql/query.rb
+++ b/lib/activegraphql/query.rb
@@ -19,7 +19,7 @@ module ActiveGraphQL
 
     def request_options
       { query: { query: to_s } }.tap do |opts|
-        opts.merge!(headers: { 'accept_language' => locale.to_s }) if locale.present?
+        opts.merge!(headers: { 'Accept-Language' => locale.to_s }) if locale.present?
       end
     end
 

--- a/spec/activegraphql/query_spec.rb
+++ b/spec/activegraphql/query_spec.rb
@@ -54,7 +54,7 @@ describe ActiveGraphQL::Query do
         let(:locale) { :en }
 
         let(:expected_request_options) do
-          { headers: { 'accept_language' => locale.to_s },
+          { headers: { 'Accept-Language' => locale.to_s },
             query: { query: expected_query_with_params } }
         end
 


### PR DESCRIPTION
This is a fix to use non underscored header.

Underscored headers can produce problems in some servers. For example nginx:
http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers
