### PR TITLE
Support for retriable and timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,26 +106,21 @@ Any fetcher provides the `in_locale(locale)` method that makes the call to inclu
 ```
 
 ## Configuration
-### Timeout
-Request timeout is configurable (by default will be the default set by [HttParty](https://github.com/jnunemaker/httparty)):
+### Http
+`ActiveGraphQL::Query` uses [HttParty](https://github.com/jnunemaker/httparty) as codebase for http calls.
+The [http options](http://www.rubydoc.info/github/jnunemaker/httparty/HTTParty/ClassMethods) used to perform requests can be configured.
 
 ```ruby
 class MyModel < ActiveGraphQL::Model
-  configure timeout: 0.1
+  configure http: { timeout: 0.1 }
 end
 ```
 
 ### Retriable
 This gem supports retriable strategy with randomized exponential backoff, based on [Retriable](https://github.com/kamui/retriable).
+Retriable is disabled by default, so `ActiveGraphQL::Model.configure` accepts the available options for [Retriable#retriable](https://github.com/kamui/retriable#options).
 
-Retriable is disabled by default, so `ActiveGraphQL::Model.configure` accepts the following options:
-
-- `tries` (default: 3) - Number of attempts to make at running your code block (includes intial attempt).
-- `base_interval` (default: 0.5) - The initial interval in seconds between tries.
-- `max_interval` (default: 60) - The maximum interval in seconds that any try can reach.
-- `on` (default: [StandardError]) - An Array of exceptions to rescue for each try, a Hash where the keys are Exception classes and the values can be a single Regexp pattern or a list of patterns, or a single Exception type.
-
-NOTE: Configuring `retriable: true` will activate Retriable with its defaults.
+NOTE: Configuring `retriable: true` will activate `Retriable` with its defaults.
 
 ```ruby
 class MyModel < ActiveGraphQL::Model

--- a/README.md
+++ b/README.md
@@ -104,3 +104,34 @@ Any fetcher provides the `in_locale(locale)` method that makes the call to inclu
 >> MyModel.all.in_locale('es_ES').fetch(:some_attribute).first.some_attribute
 => "Este es mi texto"
 ```
+
+## Configuration
+### Timeout
+Request timeout is configurable (by default will be the default set by [HttParty](https://github.com/jnunemaker/httparty)):
+
+```ruby
+class MyModel < ActiveGraphQL::Model
+  configure timeout: 0.1
+end
+```
+
+### Retriable
+This gem supports retriable strategy with randomized exponential backoff, based on [Retriable](https://github.com/kamui/retriable).
+
+Retriable is disabled by default, so `ActiveGraphQL::Model.configure` accepts the following options:
+
+- `tries` (default: 3) - Number of attempts to make at running your code block (includes intial attempt).
+- `base_interval` (default: 0.5) - The initial interval in seconds between tries.
+- `max_interval` (default: 60) - The maximum interval in seconds that any try can reach.
+- `on` (default: [StandardError]) - An Array of exceptions to rescue for each try, a Hash where the keys are Exception classes and the values can be a single Regexp pattern or a list of patterns, or a single Exception type.
+
+NOTE: Configuring `retriable: true` will activate Retriable with its defaults.
+
+```ruby
+class MyModel < ActiveGraphQL::Model
+  configure retriable: { on: [Timeout::Error, Errno::ECONNRESET],
+                         tries: 10,
+                         base_interval: 0.5,
+                         max_interval: 1 }
+end
+```

--- a/activegraphql.gemspec
+++ b/activegraphql.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hashie', '~> 3.4'
   spec.add_dependency 'activesupport', '~> 4.2'
   spec.add_dependency 'httparty', '~> 0.13'
+  spec.add_dependency 'retriable', '~> 2.0'
 end

--- a/lib/activegraphql/fetcher.rb
+++ b/lib/activegraphql/fetcher.rb
@@ -1,8 +1,9 @@
 require 'activegraphql/support/fancy'
+require 'retriable'
 
 module ActiveGraphQL
   class Fetcher < Support::Fancy
-    attr_accessor :url, :klass, :action, :params, :query
+    attr_accessor :config, :klass, :action, :params, :query
 
     class Error < StandardError; end
 
@@ -11,7 +12,7 @@ module ActiveGraphQL
     end
 
     def query
-      @query ||= Query.new(url: url, action: action, params: params)
+      @query ||= Query.new(config: config, action: action, params: params)
     end
 
     def in_locale(locale)
@@ -20,7 +21,8 @@ module ActiveGraphQL
     end
 
     def fetch(*graph)
-      response = query.get(*graph)
+      response = query_get(*graph)
+
       return if response.blank?
 
       case response
@@ -31,6 +33,35 @@ module ActiveGraphQL
       else
         raise Error, "Unexpected response for query: #{response}"
       end
+    end
+
+    def query_get(*graph)
+      Retriable.retriable(retriable_config) { query.get(*graph) }
+    end
+
+    def retriable_config
+      # use defaults if retriable config is not a hash (ie. retriable: true | false)
+      @retriable_config ||=
+        if config[:retriable].is_a?(Hash)
+          default_retriable_options.merge(
+            config[:retriable].slice(*retriable_supported_options)
+          )
+        else
+          default_retriable_options
+        end
+    end
+
+    # Supported configuration options for retriable
+    def retriable_supported_options
+      @retries_accepted_options ||= [:on, :tries, :base_interval, :max_interval]
+    end
+
+    # Defaults are:
+    #  - { tries: 1 } if there's no retriable config.
+    #  - {} if the config is enabled but with no hash (it will use the defaults from Retriable)
+    def default_retriable_options
+      @default_retriable_options ||=
+        config[:retriable].blank? ? { tries: 1 } : {}
     end
   end
 end

--- a/lib/activegraphql/fetcher.rb
+++ b/lib/activegraphql/fetcher.rb
@@ -43,17 +43,10 @@ module ActiveGraphQL
       # use defaults if retriable config is not a hash (ie. retriable: true | false)
       @retriable_config ||=
         if config[:retriable].is_a?(Hash)
-          default_retriable_options.merge(
-            config[:retriable].slice(*retriable_supported_options)
-          )
+          default_retriable_options.merge(config[:retriable])
         else
           default_retriable_options
         end
-    end
-
-    # Supported configuration options for retriable
-    def retriable_supported_options
-      @retries_accepted_options ||= [:on, :tries, :base_interval, :max_interval]
     end
 
     # Defaults are:

--- a/lib/activegraphql/model.rb
+++ b/lib/activegraphql/model.rb
@@ -6,7 +6,7 @@ module ActiveGraphQL
     class Error < StandardError; end
 
     class << self
-      attr_accessor :url
+      attr_accessor :config
 
       # This provides ability to configure the class inherited from here.
       #  Also field classes will have the configuration.
@@ -19,13 +19,14 @@ module ActiveGraphQL
       #    class ModelToMyService < BaseModelToMyService
       #    end
       #
-      #    BaseModelToMyService.url
-      #    => "http://localhost:3000/graphql"
+      #    BaseModelToMyService.config
+      #    => { url: "http://localhost:3000/graphql" }
       #
       #    ModelToMyService.url
-      #    => "http://localhost:3000/graphql"
-      def configure(url: nil)
-        configurable_class.url = url
+      #    => { url: "http://localhost:3000/graphql" }
+      def configure(config = {})
+        configurable_class.config ||= {}
+        configurable_class.config.merge!(config)
       end
 
       # Resolves the class who is extending from ActiveGraphql::Model.
@@ -49,7 +50,7 @@ module ActiveGraphQL
       end
 
       def build_fetcher(action, params = nil)
-        Fetcher.new(url: configurable_class.url,
+        Fetcher.new(config: configurable_class.config,
                     klass: self,
                     action: action,
                     params: params)

--- a/lib/activegraphql/query.rb
+++ b/lib/activegraphql/query.rb
@@ -4,14 +4,14 @@ require 'activegraphql/support/fancy'
 
 module ActiveGraphQL
   class Query < Support::Fancy
-    attr_accessor :url, :action, :params, :locale, :graph, :response
+    attr_accessor :config, :action, :params, :locale, :graph, :response
 
     class ServerError < StandardError; end
 
     def get(*graph)
       self.graph = graph
 
-      self.response = HTTParty.get(url, request_options)
+      self.response = HTTParty.get(config[:url], request_options)
 
       raise(ServerError, response_error_messages) if response_errors.present?
       response_data
@@ -20,6 +20,7 @@ module ActiveGraphQL
     def request_options
       { query: { query: to_s } }.tap do |opts|
         opts.merge!(headers: { 'Accept-Language' => locale.to_s }) if locale.present?
+        opts.merge!(timeout: config[:timeout]) if config[:timeout].present?
       end
     end
 

--- a/lib/activegraphql/query.rb
+++ b/lib/activegraphql/query.rb
@@ -20,7 +20,7 @@ module ActiveGraphQL
     def request_options
       { query: { query: to_s } }.tap do |opts|
         opts.merge!(headers: { 'Accept-Language' => locale.to_s }) if locale.present?
-        opts.merge!(timeout: config[:timeout]) if config[:timeout].present?
+        opts.merge!(config[:http]) if config[:http].present?
       end
     end
 

--- a/spec/activegraphql/model_spec.rb
+++ b/spec/activegraphql/model_spec.rb
@@ -1,7 +1,10 @@
 describe ActiveGraphQL::Model do
+  config = { url: 'service_url',
+             retriable: { tries: 3 } }
+
   let(:configured_class) do
     ConfiguredClass ||= Class.new(described_class) do
-      configure url: 'service_url'
+      configure config
     end
   end
 
@@ -13,8 +16,7 @@ describe ActiveGraphQL::Model do
 
     context 'with configured class' do
       let(:klass) { configured_class }
-
-      its(:url) { is_expected.to eq 'service_url' }
+      its(:config) { is_expected.to eq config }
       its(:klass) { is_expected.to eq klass }
       its(:action) { is_expected.to eq action }
       its(:params) { is_expected.to eq params }
@@ -22,8 +24,7 @@ describe ActiveGraphQL::Model do
 
     context 'with class inheriting the configured one' do
       let(:klass) { Class.new(configured_class) }
-
-      its(:url) { is_expected.to eq 'service_url' }
+      its(:config) { is_expected.to eq config }
       its(:klass) { is_expected.to eq klass }
       its(:action) { is_expected.to eq action }
       its(:params) { is_expected.to eq params }
@@ -41,7 +42,7 @@ describe ActiveGraphQL::Model do
 
   describe '.all', with_expected_fetcher: true do
     let(:expected_fetcher_params) do
-      { url: 'service_url',
+      { config: config,
         klass: configured_class,
         action: :configured_classes,
         params: nil }
@@ -56,7 +57,7 @@ describe ActiveGraphQL::Model do
     let(:conditions) { double(:conditions) }
 
     let(:expected_fetcher_params) do
-      { url: 'service_url',
+      { config: config,
         klass: configured_class,
         action: :configured_classes,
         params: conditions }
@@ -71,7 +72,7 @@ describe ActiveGraphQL::Model do
     let(:conditions) { double(:conditions) }
 
     let(:expected_fetcher_params) do
-      { url: 'service_url',
+      { config: config,
         klass: configured_class,
         action: :configured_class,
         params: conditions }

--- a/spec/activegraphql/query_spec.rb
+++ b/spec/activegraphql/query_spec.rb
@@ -53,7 +53,8 @@ describe ActiveGraphQL::Query do
       end
 
       let(:config) do
-        { url: url, timeout: 0.1 }
+        { url: url,
+          http: { timeout: 0.1 } }
       end
 
       it { is_expected.to eq(some_expected: 'data') }


### PR DESCRIPTION
This PR provides ActiveGraphQL with:
- Support of retry strategy based on [Retriable](https://github.com/kamui/retriable).
- Support of requests timeout configuration.

Having these changes in place, an ActiveGraphQL model could be configured doing something like:

``` ruby
class Model < ActiveGraphQL::Model
   configure url: 'http://some.api.domain',
             timeout: 0.1,
             retriable: { tries: 10,
                          base_interval: 0.5,
                          max_interval: 1 }
end
```
