### PR TITLE
Accept nil responses

### DIFF
--- a/lib/activegraphql/fetcher.rb
+++ b/lib/activegraphql/fetcher.rb
@@ -29,6 +29,8 @@ module ActiveGraphQL
         klass.new(response)
       when Array
         response.map { |h| klass.new(h) }
+      when NilClass
+        return nil
       else
         raise Error, "Unexpected response for query: #{response}"
       end

--- a/spec/activegraphql/fetcher_spec.rb
+++ b/spec/activegraphql/fetcher_spec.rb
@@ -53,6 +53,12 @@ describe ActiveGraphQL::Fetcher do
 
         it { is_expected.to be_nil }
       end
+
+      context 'with nil response' do
+        let(:query_response) { nil }
+
+        it { is_expected.to be_nil }
+      end
     end
 
     context 'with array response' do


### PR DESCRIPTION
As far as I can tell from the GraphQL specification
nil/null responses can be returned in any place,
that does not explicitly promise non-null (using `!`).

This MR therefore handles the NilClass case explicitly, so
that code like

```ruby
MyModel.find_by(foo: '1').fetch(:bar)
```

returns `nil` instead of raising an error.

## Reproduction

Using the `graphql` gem, you can reproduce a `nil` response using the following `QueryType`:

```ruby
QueryType = GraphQL::ObjectType.define do
  name 'Query'
  description 'A sample query root'

  field :foo do
    type FooType
    argument :uuid, types.String

    resolve -> (*_) { nil } # or with ActiveRecord: Foo.find_by(uuid: 'some_uuid')
  end
end

FooType = GraphQL::ObjectType.define { name 'Foo' }
```