### PR TITLE
Fix argument serialization for non-strings

### DIFF
--- a/lib/activegraphql/query.rb
+++ b/lib/activegraphql/query.rb
@@ -64,10 +64,21 @@ module ActiveGraphQL
       return if params.blank?
 
       param_strings = params.map do |k, v|
-        "#{k.to_s.camelize(:lower)}: \"#{v}\""
+        "#{k.to_s.camelize(:lower)}: #{qargument(v)}"
       end
 
       param_strings.join(', ')
+    end
+
+    def qargument(value)
+      case value
+      when Array
+        "[#{value.map{ |v| qargument(v) }.join(', ')}]"
+      when String
+        "\"#{value}\""
+      else
+        value.to_s
+      end
     end
 
     def qgraph(graph)

--- a/spec/activegraphql/query_spec.rb
+++ b/spec/activegraphql/query_spec.rb
@@ -151,8 +151,26 @@ describe ActiveGraphQL::Query do
       it { is_expected.to be_nil }
     end
 
-    context 'with params' do
+    context 'with string params' do
       it { is_expected.to eq "someLongParamName1: \"value1\", someLongParamName2: \"value2\"" }
+    end
+
+    context 'with array param' do
+      let(:params) { { array_param: ['foo', 'bar'] } }
+
+      it { is_expected.to eq 'arrayParam: ["foo", "bar"]' }
+    end
+
+    context 'with boolean params' do
+      let(:params) { { true_param: true, false_param: false } }
+
+      it { is_expected.to eq 'trueParam: true, falseParam: false' }
+    end
+
+    context 'with integer param' do
+      let(:params) { { int_param: 42 } }
+
+      it { is_expected.to eq 'intParam: 42' }
     end
   end
 


### PR DESCRIPTION
Until now all arguments were treated as strings.

For example:

```ruby
MyModel.where(foo: ['a', 'b']).fetch(:bar)
```

Would result in the following query:
```graphql
{ debitors(foo: "["a", "b"]") { bar } }
```

This causes a syntax error when parsing it.

The correct query would be:
```graphql
{ debitors(foo: ["a", "b"]) { bar } }
```

While I could not find documentation on the expected argument
formats, GraphQL in general distinguishes different types.
I explicitly implemented the types that I tested against
an actual GraphQL server. For all other types I used to_s
as a fallback, since that works for the types that come to my mind:

  * integers
  * booleans
  * floats (at least when stringified as 1.0, did not check if exponential notation is supported)