### PR TITLE
Implement ability to pass query variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Resolved query:
 { myModel("id": "5") { id, name, nestedObject { description } } }
 ```
 
+## Variables
+Any fetcher provides the `with_variables(variables_hash)` method that appends request body with `variables` param. It could contain any meta data that is acceptable by your GraphQL serivce (pagination, sorting,  directives, etc)
+
+```ruby
+>> MyModel.all.with_variables(limit: 25).fetch(:some_attribute).size
+=> 25
+```
+
 ## Localisation support
 Any fetcher provides the `in_locale(locale)` method that makes the call to include the `HTTP_ACCEPT_LANGUAGE` header to get the content localized in case of the service supporting it.
 

--- a/lib/activegraphql/fetcher.rb
+++ b/lib/activegraphql/fetcher.rb
@@ -20,6 +20,11 @@ module ActiveGraphQL
       self
     end
 
+    def with_variables(variables_hash)
+      query.merge_variables(variables_hash)
+      self
+    end
+
     def fetch(*graph)
       response = query_get(*graph)
 

--- a/lib/activegraphql/query.rb
+++ b/lib/activegraphql/query.rb
@@ -4,9 +4,15 @@ require 'activegraphql/support/fancy'
 
 module ActiveGraphQL
   class Query < Support::Fancy
-    attr_accessor :config, :action, :params, :locale, :graph, :response
+    attr_accessor :config, :action, :params, :locale, :variables, :graph,
+                  :response
 
     class ServerError < StandardError; end
+
+    def initialize(attrs = {})
+      @variables = {}
+      super
+    end
 
     def get(*graph)
       self.graph = graph
@@ -33,7 +39,9 @@ module ActiveGraphQL
     end
 
     def request_params
-      { query: to_s }
+      { query: to_s }.tap do |params|
+        params[:variables] = variables if variables.present?
+      end
     end
 
     def response_data
@@ -92,6 +100,10 @@ module ActiveGraphQL
       end
 
       graph_strings.join(', ')
+    end
+
+    def merge_variables(variables_hash)
+      @variables = @variables.merge(variables_hash)
     end
 
     private

--- a/spec/activegraphql/fetcher_spec.rb
+++ b/spec/activegraphql/fetcher_spec.rb
@@ -27,6 +27,14 @@ describe ActiveGraphQL::Fetcher do
     end
   end
 
+  describe '#with_variables' do
+    let(:variables_hash) { { skip: 20, limit: 10 } }
+
+    subject { fetcher.with_variables(variables_hash).query }
+
+    its(:variables) { is_expected.to eq variables_hash }
+  end
+
   describe '#fetch' do
     before do
       expect(fetcher)

--- a/spec/activegraphql/query_spec.rb
+++ b/spec/activegraphql/query_spec.rb
@@ -34,6 +34,7 @@ describe ActiveGraphQL::Query do
     'attr1, object { nestedAttr, nestedObject { superNestedAttr } }, attr2 }' \
     ' }'
   end
+  let(:variables_hash) { { skip: 20, limit: 10 } }
 
   describe '#get' do
     let(:response) do
@@ -77,6 +78,21 @@ describe ActiveGraphQL::Query do
           end
 
           before { query.locale = locale }
+
+          it { is_expected.to eq(some_expected: 'data') }
+        end
+
+        context 'with variables' do
+          let(:expected_request_options) do
+            {
+              query: {
+                query: expected_query_with_params,
+                variables: variables_hash
+              }
+            }
+          end
+
+          before { query.variables = variables_hash }
 
           it { is_expected.to eq(some_expected: 'data') }
         end
@@ -178,5 +194,29 @@ describe ActiveGraphQL::Query do
     subject { query.qgraph(graph) }
 
     it { is_expected.to eq 'attr1, object { nestedAttr, nestedObject { superNestedAttr } }, attr2' }
+  end
+
+  describe '#merge_variables' do
+    subject { query.merge_variables(variables_hash) }
+
+    context 'when there are no variables before' do
+      it do
+        subject
+        expect(query.variables).to eq(variables_hash)
+      end
+    end
+
+    context 'when there are some variables' do
+      let(:other_variables) { { withFriends: true } }
+
+      before do
+        query.variables = other_variables
+      end
+
+      it do
+        subject
+        expect(query.variables).to include(variables_hash, other_variables)
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds `#with_variables` method to `ActiveGraphQL::Fetcher`

### Why?
It would be really cool to have the ability to pass `variables` to the GraphQL request. It would make us able to implement a variety of useful features like pagination, sorting, directives and so on.

https://graphql.org/learn/queries/#variables